### PR TITLE
install missing glvnd EGL vendor file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nvidia-graphics-drivers-375 (375.39-0ubuntu3) UNRELEASED; urgency=medium
+
+  * debian/nvidia-375.install:
+    - install glvnd EGL vendor configuration file (LP: #1674677)
+
+ -- Thomas Foster <thomasvfoster@gmail.com>  Sat, 25 Mar 2017 13:49:35 +0000
+
 nvidia-graphics-drivers-375 (375.39-0ubuntu2) zesty; urgency=medium
 
   * debian/dkms_nvidia/patches/buildfix_kernel_4.10.patch:

--- a/debian/nvidia-375.install
+++ b/debian/nvidia-375.install
@@ -33,5 +33,6 @@ NVIDIA-Linux-x86-375.39/nvidia-persistenced /usr/lib/nvidia-375/bin
 NVIDIA-Linux-x86-375.39/nvidia-application-profiles-375.39-rc /usr/share/nvidia-375
 NVIDIA-Linux-x86-375.39/nvidia-application-profiles-375.39-key-documentation /usr/share/nvidia-375
 
+NVIDIA-Linux-x86-375.39/10_nvidia.json usr/share/glvnd/egl_vendor.d
 NVIDIA-Linux-x86-375.39/nvidia_icd.json usr/share/vulkan/icd.d
 NVIDIA-Linux-x86-375.39/nvidia-drm-outputclass.conf  usr/share/X11/xorg.conf.d/50-nvidia-drm-outputclass.conf

--- a/debian/templates/nvidia-graphics-drivers.install.in
+++ b/debian/templates/nvidia-graphics-drivers.install.in
@@ -33,5 +33,6 @@ debian/dkms_nvidia/dkms.conf                  usr/src/#DRIVERNAME#-#VERSION#
 #DIRNAME#/nvidia-application-profiles-#VERSION#-rc #PKGDATADIR#
 #DIRNAME#/nvidia-application-profiles-#VERSION#-key-documentation #PKGDATADIR#
 
+#DIRNAME#/10_nvidia.json usr/share/glvnd/egl_vendor.d
 #ARM_EXCLUDED##DIRNAME#/nvidia_icd.json usr/share/vulkan/icd.d
 #DIRNAME#/nvidia-drm-outputclass.conf  usr/share/X11/xorg.conf.d/50-nvidia-drm-outputclass.conf


### PR DESCRIPTION
This change addresses [LP #1674677](https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-375/+bug/1674677).  The `libEGL.so` installed by `nvidia-375` requires files in `/usr/share/glvnd/egl_vendor.d/` describing EGL vendor implementations in order to work properly.