### PR TITLE
libnvidia-compute- should not Conflicts/Replaces opencl-icd

### DIFF
--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -111,10 +111,10 @@ Recommends:
 Provides: nvidia-opencl-icd, opencl-icd, libcuda-5.0-1, libcuda-5.5-1,
  libcuda-6.0-1, libcuda-6.5-1, libcuda-7.0-1, libcuda-7.5-1, libcuda-8.0-1,
  libcuda-9.0-1, libcuda-9.1-1
-Conflicts: nvidia-opencl-icd, opencl-icd, libcuda-5.0-1, libcuda-5.5-1,
+Conflicts: nvidia-opencl-icd, libcuda-5.0-1, libcuda-5.5-1,
  libcuda-6.0-1, libcuda-6.5-1, libcuda-7.0-1, libcuda-7.5-1, libcuda-8.0-1,
  libcuda-9.0-1, libcuda-9.1-1
-Replaces: nvidia-opencl-icd, opencl-icd, libcuda-5.0-1, libcuda-5.5-1,
+Replaces: nvidia-opencl-icd, libcuda-5.0-1, libcuda-5.5-1,
  libcuda-6.0-1, libcuda-6.5-1, libcuda-7.0-1, libcuda-7.5-1, libcuda-8.0-1,
  libcuda-9.0-1, libcuda-9.1-1, libnvidia-compute-#FLAVOUR# (<< 390.25-0ubuntu2~)
 Description: NVIDIA libcompute package


### PR DESCRIPTION
OpenCL ICDs should be co-installable