### PR TITLE
udev: remove nvidia-smi from run list

### DIFF
--- a/debian/71-nvidia.rules
+++ b/debian/71-nvidia.rules
@@ -24,8 +24,5 @@ ACTION=="remove" DEVPATH=="/module/nvidia" SUBSYSTEM=="module" RUN+="/sbin/modpr
 ACTION=="add" DEVPATH=="/module/nvidia" SUBSYSTEM=="module" RUN+="/sbin/modprobe nvidia-uvm"
 ACTION=="remove" DEVPATH=="/module/nvidia" SUBSYSTEM=="module" RUN+="/sbin/modprobe -r nvidia-uvm"
 
-# This will create the device nvidia device nodes
-ACTION=="add" DEVPATH=="/module/nvidia" SUBSYSTEM=="module" RUN+="/usr/bin/nvidia-smi"
-
 # Call create-uvm-dev-node when an NVIDIA GPU is added
 ACTION=="add", SUBSYSTEMS=="pci", DRIVERS=="nvidia*", RUN+="/opt/nvidia/sbin/create-uvm-dev-node"


### PR DESCRIPTION
nvidia-smi was previously used for creating device nodes when nvidia kernel module is being loaded. This is no longer mandatory as the device nodes (nvidia0 & nvidiactl) will be created by any other process linking to libnvidia-ml.so, e.g. nvidia-settings, when necessary.