### PR TITLE
udev: Add rules to enable runtime PM by default

### DIFF
--- a/debian/71-nvidia.rules
+++ b/debian/71-nvidia.rules
@@ -23,3 +23,15 @@ ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/ub-device-create"
 
 # Create the device node for the nvidia-uvm module
 ACTION=="add", DEVPATH=="/module/nvidia_uvm", SUBSYSTEM=="module", RUN+="/sbin/ub-device-create"
+
+# Enable runtime PM for NVIDIA VGA/3D controller devices
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
+
+# Enable runtime PM for NVIDIA Audio devices
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="auto"
+
+# Enable runtime PM for NVIDIA USB xHCI Host Controller devices
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", TEST=="power/control", ATTR{power/control}="auto"
+
+# Enable runtime PM fo NVIDIA USB Type-C UCSI devices
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", TEST=="power/control", ATTR{power/control}="auto"


### PR DESCRIPTION
Enable runtime PM for all functions on Nvidia PCI device, to let Nvidia
device reach D3cold.

Tested and verified on Focal 5.4, OEM 5.6 and Groovy 5.8 kernels.