### PR TITLE
udev: Enable runtime PM after driver is bound

### DIFF
--- a/debian/71-nvidia.rules
+++ b/debian/71-nvidia.rules
@@ -25,7 +25,7 @@ ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/ub-device-create"
 ACTION=="add", DEVPATH=="/module/nvidia_uvm", SUBSYSTEM=="module", RUN+="/sbin/ub-device-create"
 
 # Enable runtime PM for NVIDIA VGA/3D controller devices
-ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
 
 # Enable runtime PM for NVIDIA Audio devices
 ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="auto"


### PR DESCRIPTION
We are facing an issue that GDM starts with Wayland instead of Xorg,
despite of 61-gdm.rules' gdm-disable-wayland for NVIDIA graphics.

The issue happens because gdm-disable-wayland is executed after GDM has
started. The reason why the udev rules takes so long is because the the
runtime suspended NVIDIA GFX takes more than 1 second to runtime resume,
hence the driver starts the probing routine rather late.

The proper solution is to impose a barrier like
systemd-udev-settle.service before GDM, but limits to the GFX device
only to avoid waiting for all udev rules are finished.

Since such mechanism isn't available right now, workaround the issue by
enabling runtime PM after driver is bound to avoid the runtime resume
delay, and hope GDM always starts after the probing is done.