### PR TITLE
Move nvidia-drm_gbm.so into the gbm/ library subdirectory

### DIFF
--- a/debian/libnvidia-extra-495.links
+++ b/debian/libnvidia-extra-495.links
@@ -1,3 +1,3 @@
-usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1        usr/lib/x86_64-linux-gnu/nvidia-drm_gbm.so
+usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1        usr/lib/x86_64-linux-gnu/gbm/nvidia-drm_gbm.so
 usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.495.44               usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1
 usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1                       usr/lib/x86_64-linux-gnu/libnvidia-allocator.so

--- a/debian/templates/libnvidia-extra-flavour.links.in
+++ b/debian/templates/libnvidia-extra-flavour.links.in
@@ -1,3 +1,3 @@
-#I386_EXCLUDED##LIBDIR#/libnvidia-allocator.so.1        #LIBDIR#/nvidia-drm_gbm.so
+#I386_EXCLUDED##LIBDIR#/libnvidia-allocator.so.1        #LIBDIR#/gbm/nvidia-drm_gbm.so
 #LIBDIR#/libnvidia-allocator.so.#VERSION#               #LIBDIR#/libnvidia-allocator.so.1
 #LIBDIR#/libnvidia-allocator.so.1                       #LIBDIR#/libnvidia-allocator.so


### PR DESCRIPTION
which is where Mesa searches for it. ([LP: #1951085](https://launchpad.net/bugs/1951085))