### PR TITLE
Fix regex does not work in dash LP: #1964756

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -262,7 +262,7 @@ generate-modaliases:
 	# Generate a modalias for each ID
 	@set -e -x ; \
 	while read line; do \
-		[ "$$line"=~"#.*" ] && continue; \
+		echo $$line | grep -Eq '^#.*' && continue; \
 		for id in $$line; do \
 			printf 'alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n' \
 				0x10de "0x$$id" "$(pkg_module)" "$(pkg_meta)"; \


### PR DESCRIPTION
```
# Take additional card ids from a text file
# Generate a modalias for each ID
+ read line
+ echo # Uncomment the following line, and add card IDs:
+ grep -Eq ^#.*
+ continue
+ read line
+ echo 2438 24BA 24BB 25B9 25BA
+ grep -Eq ^#.*
+ printf alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n 0x10de 0x2438 nvidia nvidia-driver-510
+ printf alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n 0x10de 0x24BA nvidia nvidia-driver-510
+ printf alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n 0x10de 0x24BB nvidia nvidia-driver-510
+ printf alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n 0x10de 0x25B9 nvidia nvidia-driver-510
+ printf alias pci:v%08Xd%08Xsv*sd*bc03sc*i* %s %s\n 0x10de 0x25BA nvidia nvidia-driver-510
+ read line
cat /home/ubuntu/Templates/nvidia-graphics-drivers-510/debian/nvidia-driver-510.modaliases
...
alias pci:v000010DEd00002438sv*sd*bc03sc*i* nvidia nvidia-driver-510
alias pci:v000010DEd000024BAsv*sd*bc03sc*i* nvidia nvidia-driver-510
alias pci:v000010DEd000024BBsv*sd*bc03sc*i* nvidia nvidia-driver-510
alias pci:v000010DEd000025B9sv*sd*bc03sc*i* nvidia nvidia-driver-510
alias pci:v000010DEd000025BAsv*sd*bc03sc*i* nvidia nvidia-driver-510
```

```
$ readlink -f $(which sh)
/usr/bin/dash
```

Fixed https://bugs.launchpad.net/oem-priority/+bug/1964756