### PR TITLE
Update libnvidia-nvvm.so version tag

### DIFF
--- a/debian/templates/libnvidia-compute-flavour.links.in
+++ b/debian/templates/libnvidia-compute-flavour.links.in
@@ -1,5 +1,5 @@
 #I386_EXCLUDED##LIBDIR#/libnvidia-nvvm.so.4            #LIBDIR#/libnvidia-nvvm.so
-#I386_EXCLUDED##LIBDIR#/libnvidia-nvvm.so.4.0.0        #LIBDIR#/libnvidia-nvvm.so.4
+#I386_EXCLUDED##LIBDIR#/libnvidia-nvvm.so.#VERSION#    #LIBDIR#/libnvidia-nvvm.so.4
 #LIBDIR#/libcuda.so.#VERSION#                          #LIBDIR#/libcuda.so.1
 #LIBDIR#/libcuda.so.1                                  #LIBDIR#/libcuda.so
 #LIBDIR#/libnvidia-ml.so.#VERSION#                     #LIBDIR#/libnvidia-ml.so.1


### PR DESCRIPTION
515 driver series have changed the version tag of libnvidia-nvvm.so. The library is still loaded through the libnvidia-nvvm.so.4 name.