### PR TITLE
templates: version restrict disable_fstack-clash-protection_fcf-protection patch

### DIFF
--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -13,5 +13,7 @@ BUILT_MODULE_NAME[2]="nvidia-drm"
 DEST_MODULE_LOCATION[2]="/kernel/drivers/char/drm"
 AUTOINSTALL="yes"
 PATCH[0]="disable_fstack-clash-protection_fcf-protection.patch"
-#PATCH[1]="do-not-call-pci_save_state.patch"
-#PATCH_MATCH[0]="^4.[6-7]"
+# Apply from v4 to v5.12 kernels
+# v5.13 kernels already disable both by default
+# v5.19 kernels may need cf-protection=branch
+PATCH_MATCH[0]='^(4\.[0-9]*)|(5\.[0-9]\.0)|(5\.1[0-2]\.0)'


### PR DESCRIPTION
Add PATCH_MATCH[0] stanza to disable_fstack-clash-protection_fcf-protection.patch to only apply from v4 to v5.12 kernels. v5.13 kernels already disable both by default. But in jammy/kinetic v5.19+ kernels may need fcf-protection=branch as inherited from kernel config with CET IBT turned on.

This patch is needed in jammy+ nvidia packages, but is safe to apply everywhere.