### PR TITLE
templates: disable IBT linking by default

### DIFF
--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"


### PR DESCRIPTION
Currently nvidia drivers are not compatible with IBT. When kernel has IBT turned on, it tries to compile code with correct compiler flags and post-process object files with kernel objtool. This is futile, given that prebuilt nvidia object file is incompatible. But also this currently breaks LRM builds as they have not yet been adjusted to depend and call objtool.

Unsetting CONFIG_X86_KERNEL_IBT= will allow to turn IBT on for the majority of kernel modules, whilst continuing to build nvidia modules without IBT. This will in turn allow running systems in ibt=warn mode with nvidia drivers. Or with fatal enforcement alas without nvidia modules.

This is a temporary stage until nvidia drivers gain IBT support.