### PR TITLE
Split firmware into standalone package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -97,6 +97,7 @@ Depends:
  nvidia-kernel-source-530 (>= 530.41.03),
  nvidia-kernel-common-530 (<= 530.41.03-1),
  nvidia-kernel-common-530 (>= 530.41.03),
+ nvidia-firmware-530-530.41.03,
  ${misc:Depends}, ${shlibs:Depends}
 Description: NVIDIA DKMS package
  This package builds the NVIDIA kernel module needed by the userspace
@@ -215,7 +216,7 @@ Architecture: amd64 arm64
 Conflicts: nvidia-kernel-common
 Provides: nvidia-kernel-common
 Depends:
- ${misc:Depends}, ${shlibs:Depends}
+ ${misc:Depends}, ${shlibs:Depends}, nvidia-firmware-530-530.41.03
 Replaces:
  nvidia-dkms-530 (<< 390.48-0ubuntu3~), nvidia-kernel-common
 Description: Shared files used with the kernel module
@@ -225,6 +226,12 @@ Description: Shared files used with the kernel module
  Install this package if you want to blacklist any conflicting kernel
  modules, and if you want udev to load the the NVIDIA kernel modules,
  and to create the uvm devices automatically.
+
+Package: nvidia-firmware-530-530.41.03
+Architecture: amd64 arm64
+Description: Firmware files used by the kernel module
+ This package installs required firmware files for the NVIDIA kernel
+ module.
 
 Package: libnvidia-gl-530
 Architecture: i386 amd64 arm64

--- a/debian/nvidia-firmware-530-530.41.03.install
+++ b/debian/nvidia-firmware-530-530.41.03.install
@@ -1,0 +1,1 @@
+NVIDIA-Linux/firmware/gsp.bin                               lib/firmware/nvidia/530.41.03

--- a/debian/rules
+++ b/debian/rules
@@ -196,12 +196,14 @@ regen-from-templates:
 		old=`echo $$i | sed -e "s|templates\/||g" | \
 				sed -e "s|\.in\$$||g" | \
 				sed -e "s|nvidia-graphics-drivers|nvidia-*|g" | \
+				sed -e "s|version|*|g" | \
 				sed -e "s|flavour|*|g"`; \
 		rm -f $$old; done
 	# Create important strings
 	for i in debian/templates/*.in; do \
 		dest=`echo $$i | sed -e "s|templates\/||g" | \
 				 sed -e "s|\.in\$$||g" | \
+				 sed -e "s|version|$(version)|g" | \
 				 sed -e "s|flavour|$(flavour)|g"`; \
 		sed -e "s|#LIBDIR#|$(libdir)|g"         \
 			-e "s|#ARMHF_ONLY#|$(armhf_only)|g" \

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -97,6 +97,7 @@ Depends:
  nvidia-kernel-source-#FLAVOUR# (>= #DEBIAN_VERSION#),
  nvidia-kernel-common-#FLAVOUR# (<= #DEBIAN_VERSION#-1),
  nvidia-kernel-common-#FLAVOUR# (>= #DEBIAN_VERSION#),
+ nvidia-firmware-#FLAVOUR#-#VERSION#,
  ${misc:Depends}, ${shlibs:Depends}
 Description: NVIDIA DKMS package
  This package builds the NVIDIA kernel module needed by the userspace
@@ -215,7 +216,7 @@ Architecture: amd64 arm64
 Conflicts: nvidia-kernel-common
 Provides: nvidia-kernel-common
 Depends:
- ${misc:Depends}, ${shlibs:Depends}
+ ${misc:Depends}, ${shlibs:Depends}, nvidia-firmware-#FLAVOUR#-#VERSION#
 Replaces:
  nvidia-dkms-#FLAVOUR# (<< 390.48-0ubuntu3~), nvidia-kernel-common
 Description: Shared files used with the kernel module
@@ -225,6 +226,12 @@ Description: Shared files used with the kernel module
  Install this package if you want to blacklist any conflicting kernel
  modules, and if you want udev to load the the NVIDIA kernel modules,
  and to create the uvm devices automatically.
+
+Package: nvidia-firmware-#FLAVOUR#-#VERSION#
+Architecture: amd64 arm64
+Description: Firmware files used by the kernel module
+ This package installs required firmware files for the NVIDIA kernel
+ module.
 
 Package: libnvidia-gl-#FLAVOUR#
 Architecture: i386 amd64 arm64

--- a/debian/templates/nvidia-firmware-flavour-version.install.in
+++ b/debian/templates/nvidia-firmware-flavour-version.install.in
@@ -1,0 +1,1 @@
+#I386_EXCLUDED#NVIDIA-Linux/firmware/gsp.bin                               lib/firmware/nvidia/#VERSION#


### PR DESCRIPTION
[LP: #2016888](https://bugs.launchpad.net/ubuntu/+source/linux-restricted-modules/+bug/2016888)
Split firmware into separate package

* Currently gsp.bin is shipped by nvidia-kernel-common that pulls in userspace dependencies and is required to match a particular driver

* This prevents co-installing LRM of different nvidia upstream releases from different kernels, entangles them together for migration, and makes it difficult to vendor LRM/drivers alone in the kernel snaps without any userspace components.

* To address some or all of the above things we need to split gsp.bin firmware into version specific package names, whilst keeping the dependency on the new nvidia-firmware-#FLAVOUR#-#VERSION#. Then once all dkms & lrms gain direct dependency on the nvidia-firmware-#FLAVOUR#-#VERSION# we will be able to consider relaxing or dropping dkms/lrm dependency on nvidia-kernel-common

* Even if we don't relax/drop the nvidia-kernel-common dependency down the line these changes will enable easier packaging of kernel snaps, and may allow in the future an easier reuse of gsp.bin by the open source driver.

NB!
If this is introduced with a new upstream release, it can be shipped as is. If this is being shipped without a new upstream release of drivers, than additional versioned Breaks:/Replaces: are needed on the nvidia-firmware-* package, to ensure it Breaks:/Replaced: the previous version of the same major upstream version. Which then would need to be dropped again in subsequent uploads. There is no time critically to land this change in all the supported series, thus it would be desired to land this only together with a new upstream release of nvidia driver across all the supported nvidia flavours.