### PR TITLE
Fix incorrect supportness of nvidia-530 (Jammy)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,7 +57,7 @@ Recommends:
  libnvidia-gl-530:i386 (= ${binary:Version}) [amd64]
 XB-Modaliases: ${modaliases}
 XB-PmAliases: ${nvidia:pm-modaliases}
-XB-Support: PB
+XB-Support: NFB
 Description: NVIDIA driver metapackage
  This metapackage depends on the NVIDIA binary driver and on all of its libraries,
  to provide hardware acceleration for OpenGL/GLX/EGL/GLES/Vulkan
@@ -394,7 +394,7 @@ Recommends:
  libnvidia-gl-530:i386 (= ${binary:Version}) [amd64]
 XB-Modaliases: ${modaliases}
 XB-PmAliases: ${nvidia:pm-modaliases}
-XB-Support: PB
+XB-Support: NFB
 Description: NVIDIA driver (open kernel) metapackage
  This metapackage depends on the NVIDIA binary driver and on all of its libraries,
  to provide hardware acceleration for OpenGL/GLX/EGL/GLES/Vulkan


### PR DESCRIPTION
Based on nVidia official webpage, nvidia-530 is NFB but PB. (Closes: #56)