### PR TITLE
535 nvidia firmware conflict

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,12 @@ version_major		 = $(firstword $(subst ., ,$(version)))
 # system libdir
 libdir			?= usr/lib/$(DEB_HOST_MULTIARCH)
 
+last_suffix            := $(lastword $(subst -, ,$(DEB_SOURCE)))
+ifeq ($(last_suffix),server)
+flavour := $(version_major)-server
+else
 flavour := $(version_major)
+endif
 pkg_meta         := nvidia-driver-$(flavour)
 pkg_meta_open    := $(pkg_meta)-open
 pkg_driver       := nvidia-$(flavour)

--- a/debian/rules
+++ b/debian/rules
@@ -22,8 +22,10 @@ libdir			?= usr/lib/$(DEB_HOST_MULTIARCH)
 last_suffix            := $(lastword $(subst -, ,$(DEB_SOURCE)))
 ifeq ($(last_suffix),server)
 flavour := $(version_major)-server
+other_flavour := $(version_major)
 else
 flavour := $(version_major)
+other_flavour := $(version_major)-server
 endif
 pkg_meta         := nvidia-driver-$(flavour)
 pkg_meta_open    := $(pkg_meta)-open
@@ -223,6 +225,7 @@ regen-from-templates:
 			-e "s|#PPC64EL_EXCLUDED#|$(ppc64el_excluded)|g" \
 			-e "s|#NVEXCLUDEMODULES#|$(DKMS_disabled_modules)|g" \
 			-e "s|#FLAVOUR#|$(flavour)|g" \
+			-e "s|#OTHER_FLAVOUR#|$(other_flavour)|g" \
 			-e "s|#DRIVERNAME#|$(pkg_driver)|g" \
 			-e "s|#VERSION#|$(version)|g" \
 			-e "s|#DEBIAN_VERSION#|$(debian_version)|g" \

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -228,6 +228,10 @@ Description: Shared files used with the kernel module
 
 Package: nvidia-firmware-#FLAVOUR#-#VERSION#
 Architecture: amd64 arm64
+Breaks:
+ nvidia-firmware-#OTHER_FLAVOUR#-#VERSION#
+Replaces:
+ nvidia-firmware-#OTHER_FLAVOUR#-#VERSION#
 Depends:
  ${misc:Depends}
 Description: Firmware files used by the kernel module


### PR DESCRIPTION
Add breaks&replaces on identical firmware files from other flavour

When 535 & 535-server driver versions happen to be at an identical
upstream version, they both ship identical firmware files on disk at
the same path. When a user attempts to install two drivers at the same
time, this results in dpkg file conflict. Allow replacing one firmware
with another.

LP: #2026622